### PR TITLE
Updated DatabaseFinal to clear and recreate database

### DIFF
--- a/BangazonDatabaseFinal.sql
+++ b/BangazonDatabaseFinal.sql
@@ -1,3 +1,69 @@
+
+IF (OBJECT_ID('dbo.FK_ComputerEmployee', 'F') IS NOT NULL)
+BEGIN
+    ALTER TABLE dbo.EmployeeComputer DROP CONSTRAINT FK_ComputerEmployee
+END
+
+IF (OBJECT_ID('dbo.FK_EmployeeComp', 'F') IS NOT NULL)
+BEGIN
+    ALTER TABLE dbo.EmployeeComputer DROP CONSTRAINT FK_EmployeeComp
+END
+
+IF (OBJECT_ID('dbo.FK_TrainingProgram', 'F') IS NOT NULL)
+BEGIN
+    ALTER TABLE dbo.EmployeeTraining DROP CONSTRAINT FK_TrainingProgram
+END
+
+IF (OBJECT_ID('dbo.FK_EmployeeTraining', 'F') IS NOT NULL)
+BEGIN
+    ALTER TABLE dbo.EmployeeTraining DROP CONSTRAINT FK_EmployeeTraining
+END
+
+IF (OBJECT_ID('dbo.FK_DepartmentEmployee', 'F') IS NOT NULL)
+BEGIN
+    ALTER TABLE dbo.Employee DROP CONSTRAINT FK_DepartmentEmployee
+END
+
+IF (OBJECT_ID('dbo.FK_CustomerProduct', 'F') IS NOT NULL)
+BEGIN
+    ALTER TABLE dbo.Product DROP CONSTRAINT FK_CustomerProduct
+END
+
+IF (OBJECT_ID('dbo.FK_ProductTypeProduct', 'F') IS NOT NULL)
+BEGIN
+    ALTER TABLE dbo.Product DROP CONSTRAINT FK_ProductTypeProduct
+END
+
+IF (OBJECT_ID('dbo.FK_OrderProductOrder', 'F') IS NOT NULL)
+BEGIN
+    ALTER TABLE dbo.ProductOrder DROP CONSTRAINT FK_OrderProductOrder
+END
+
+IF (OBJECT_ID('dbo.FK_ProductProductOrder', 'F') IS NOT NULL)
+BEGIN
+    ALTER TABLE dbo.ProductOrder DROP CONSTRAINT FK_ProductProductOrder
+END
+
+IF (OBJECT_ID('dbo.FK_CustomerPaymentOrder', 'F') IS NOT NULL)
+BEGIN
+    ALTER TABLE dbo.[Order] DROP CONSTRAINT FK_CustomerPaymentOrder
+END
+
+IF (OBJECT_ID('dbo.FK_CustomerOrder', 'F') IS NOT NULL)
+BEGIN
+    ALTER TABLE dbo.[Order] DROP CONSTRAINT FK_CustomerOrder
+END
+
+IF (OBJECT_ID('dbo.FK_PaymentTypeCustomer', 'F') IS NOT NULL)
+BEGIN
+    ALTER TABLE dbo.CustomerPayment DROP CONSTRAINT FK_PaymentTypeCustomer
+END
+
+IF (OBJECT_ID('dbo.FK_CustomerPayment', 'F') IS NOT NULL)
+BEGIN
+    ALTER TABLE dbo.CustomerPayment DROP CONSTRAINT FK_CustomerPayment
+END
+
 DROP TABLE IF EXISTS Department;
 DROP TABLE IF EXISTS Employee;
 DROP TABLE IF EXISTS EmployeeComputer;
@@ -11,6 +77,9 @@ DROP TABLE IF EXISTS TrainingProgram;
 DROP TABLE IF EXISTS Computer;
 DROP TABLE IF EXISTS Customer;
 DROP TABLE IF EXISTS CustomerPayment;
+
+
+
 CREATE TABLE Computer (
   ComputerId          INTEGER NOT NULL PRIMARY KEY IDENTITY,
   DatePurchased       DATE NOT NULL,


### PR DESCRIPTION
# Description
Added logic to DatabaseFinal to check if Foreign Key restraints exist, remove them if they do, drop any tables, create new tables and seed them with data
 Fixes # (issue)
 ## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
 # Testing Instructions
git checkout wk_DatabaseWipeAndRewrite branch
Select a database that is already populated with data in SQL Server Management Studio
Highlight the DB and select the "open file" icon
In the Bangazon directory, you will see "BangazonDatabaseFinal" -- select this
To test, push the execute button and ensure there are no red errors below.
To double check the test, click through the tables on the left-hand side, right click and select "Select top 1000 rows" for each table
You should make sure each table has three rows of seeded data. (there should be 13 tables total)
 # Checklist:
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [x] I have commented my code, particularly in hard-to-understand areas
 - [x] I have made corresponding changes to the documentation
 - [x] My changes generate no new warnings
 - [x] I have added test instructions that prove my fix is effective or that my feature works